### PR TITLE
[master] blanc: Include aosp_base instead of aosp_base_telephony

### DIFF
--- a/aosp_g1109.mk
+++ b/aosp_g1109.mk
@@ -17,7 +17,7 @@ TARGET_KERNEL_CONFIG := aosp_loire_blanc_defconfig
 # Inherit from those products. Most specific first.
 $(call inherit-product, device/sony/blanc/device.mk)
 $(call inherit-product, frameworks/native/build/phone-xhdpi-2048-dalvik-heap.mk)
-$(call inherit-product, $(SRC_TARGET_DIR)/product/aosp_base_telephony.mk)
+$(call inherit-product, $(SRC_TARGET_DIR)/product/aosp_base.mk)
 
 PRODUCT_NAME := aosp_g1109
 PRODUCT_DEVICE := blanc


### PR DESCRIPTION
Proceeding from the fact that blanc is an APQ SoC product
and it does not work with a mobile network, it makes no
sense to include additional telephony packages.

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>