### PR TITLE
[BLANC] mixer_paths: Always listen to scaler loopback audio

### DIFF
--- a/rootdir/vendor/etc/mixer_paths.xml
+++ b/rootdir/vendor/etc/mixer_paths.xml
@@ -1898,6 +1898,7 @@
         <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia1" value="1" />
         <ctl name="COMP3 Switch" value="1" />
         <ctl name="COMP4 Switch" value="1" />
+        <path name="play-hdmi-scaler-audio" />
     </path>
 
     <path name="speaker">


### PR DESCRIPTION
Enable the scaler loopback audio, so that we are able to
avoid strange modifications in AOSP for both HDMI IN
usecase and regular playback.