### PR TITLE
[BLANC] init: Enable touch buttons and bar light

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,4 +1,7 @@
-#
-# This empty Android.mk file exists to prevent the build system from
-# automatically including any other Android.mk files under this directory.
-#
+ifeq (blanc,$(PRODUCT_DEVICE))
+
+LOCAL_PATH := $(call my-dir)
+
+include $(call all-makefiles-under,$(LOCAL_PATH))
+
+endif

--- a/device.mk
+++ b/device.mk
@@ -71,7 +71,8 @@ PRODUCT_COPY_FILES += \
 PRODUCT_PACKAGES += \
     fstab.blanc \
     init.recovery.blanc \
-    init.blanc
+    init.blanc \
+    init_touchbuttons
 
 # Projection
 PRODUCT_PACKAGES += \

--- a/rootdir/Android.mk
+++ b/rootdir/Android.mk
@@ -1,0 +1,10 @@
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := init_touchbuttons
+LOCAL_SRC_FILES := vendor/etc/init/touchbuttons.rc
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_STEM := init_touchbuttons
+LOCAL_MODULE_CLASS := ETC
+LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/etc/init
+include $(BUILD_PREBUILT)

--- a/rootdir/vendor/etc/init/touchbuttons.rc
+++ b/rootdir/vendor/etc/init/touchbuttons.rc
@@ -1,0 +1,12 @@
+on init
+    # Let there be light!
+    write /sys/class/leds/as3668:volume_down/brightness 3
+    write /sys/class/leds/as3668:volume_up/brightness 3
+
+on boot
+    # Prepare the ADUX1050 capacitive sensor
+    write /sys/devices/soc/78b8000.i2c/i2c-4/4-002c/adux1050_sw_reset 1
+
+on property:sys.boot_completed=1
+    # Enable the touch buttons events
+    write /sys/devices/soc/78b8000.i2c/i2c-4/4-002c/adux1050_enable 1


### PR DESCRIPTION
The touch buttons are controlled by the ADUX1050 Capacitive
Proximity Sensor: this device can get the right calibration
only after the projection unit is up and running, so we need
to bring it up from userspace, after initlight.

Then, the touch buttons bar has got lights under it and these
ones are controlled by the supplementary AS3668 chip: raise
the brightness minimally (it's really enough) so that the
user can visually locate the points where to touch.