### PR TITLE
[BLANC] Add ToF focus calibration XML for MicroCommunicator Auto Focus

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -50,6 +50,10 @@ PRODUCT_COPY_FILES += \
     $(DEVICE_PATH)/vendor/etc/acdbdata/Headset_cal.acdb:$(TARGET_COPY_OUT_VENDOR)/etc/acdbdata/Headset_cal.acdb \
     $(DEVICE_PATH)/vendor/etc/acdbdata/Speaker_cal.acdb:$(TARGET_COPY_OUT_VENDOR)/etc/acdbdata/Speaker_cal.acdb
 
+# Focus calibration
+PRODUCT_COPY_FILES += \
+    $(DEVICE_PATH)/vendor/etc/tof_focus_calibration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/tof_focus_calibration.xml
+
 # Touch IDC
 PRODUCT_COPY_FILES += \
     $(DEVICE_PATH)/vendor/usr/idc/TouchDetector.idc:$(TARGET_COPY_OUT_VENDOR)/usr/idc/TouchDetector.idc

--- a/rootdir/vendor/etc/tof_focus_calibration.xml
+++ b/rootdir/vendor/etc/tof_focus_calibration.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<tof_focus_calibration>
+    <tof_focus>
+        <focus millimeters="2   24   47   75  102  127  152  179  230  255  305"
+               focus_step="25 -101 -171 -223 -261 -311 -328 -345 -358 -370 -383"/>
+    </tof_focus>
+</tof_focus_calibration>


### PR DESCRIPTION
MicroCommunicator now features an AF algorithm and needs
this file to read the initial calibration.