### PR TITLE
add logic to set TARGET_BOOTLOADER_BOARD_NAME

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -14,7 +14,12 @@
 
 include device/sony/loire/PlatformConfig.mk
 
-TARGET_BOOTLOADER_BOARD_NAME := loire
+TARGET_BOOTLOADER_BOARD_NAME := unknown
+ifneq (,$(filter %g1109,$(TARGET_PRODUCT)))
+TARGET_BOOTLOADER_BOARD_NAME := G1109
+else
+$(error Unrecognized value for TARGET_PRODUCT: "$(TARGET_PRODUCT)")
+endif
 
 # Platform
 PRODUCT_PLATFORM := loire


### PR DESCRIPTION
Set TARGET_BOOTLOADER_BOARD_NAME to the variant-specific board-name
(i.e. G1109).  This causes the "board" variable in "android-info.txt"
to be populated correctly, which fixes updatepackage zips.