### PR TITLE
Remove unnecessary NFC flags and packages

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -89,10 +89,6 @@ PRODUCT_PACKAGES += \
 PRODUCT_PACKAGES += \
     power.blanc
 
-# NFC config
-PRODUCT_PACKAGES += \
-    nfc_nci.blanc
-
 PRODUCT_AAPT_CONFIG := normal
 PRODUCT_AAPT_PREBUILT_DPI := xhdpi hdpi
 PRODUCT_AAPT_PREF_CONFIG := xhdpi


### PR DESCRIPTION
* These packages and flags no longer exist
  in AOSP 9 codebase.